### PR TITLE
Refactor variable names about preedit

### DIFF
--- a/docs/input.dox
+++ b/docs/input.dox
@@ -263,7 +263,7 @@ The callback receives the following information.
 
 @code
 void preedit_callback(GLFWwindow* window,
-                      int preedit_length,
+                      int preedit_count,
                       unsigned int* preedit_string,
                       int block_count,
                       int* block_sizes,
@@ -273,7 +273,7 @@ void preedit_callback(GLFWwindow* window,
 }
 @endcode
 
-"preedit_length" and "preedit_string" parameter represent the whole preedit text.
+"preedit_count" and "preedit_string" parameter represent the whole preedit text.
 Each character of the preedit string is a native endian UTF-32 like @ref input_char.
 
 If you want to type the text "寿司(sushi)", Usually the callback is called several
@@ -300,7 +300,7 @@ If preedit text includes several semantic blocks, the callback returns several b
 -# preedit: [preedit_string: "わたしはすしをたべます", block_sizes: [11], focused_block: 0]
 -# preedit: [preedit_string: "私は寿司を食べます", block_sizes: [2, 7], focused_block: 1]
 
-"block_sizes" is a list of block length.  The above case, it contains the following
+"block_sizes" is a list of the sizes of each block.  The above case, it contains the following
 blocks and the second block is focused.
 
 - 私は

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -1909,7 +1909,7 @@ typedef void (* GLFWcharmodsfun)(GLFWwindow* window, unsigned int codepoint, int
  *  This is the function pointer type for preedit callback functions.
  *
  *  @param[in] window The window that received the event.
- *  @param[in] preedit_length Preedit string length.
+ *  @param[in] preedit_count Preedit string count.
  *  @param[in] preedit_string Preedit string.
  *  @param[in] block_count Attributed block count.
  *  @param[in] block_sizes List of attributed block size.
@@ -1922,7 +1922,7 @@ typedef void (* GLFWcharmodsfun)(GLFWwindow* window, unsigned int codepoint, int
  *  @ingroup input
  */
 typedef void (* GLFWpreeditfun)(GLFWwindow* window,
-                                int preedit_length,
+                                int preedit_count,
                                 unsigned int* preedit_string,
                                 int block_count,
                                 int* block_sizes,
@@ -5302,7 +5302,7 @@ GLFWAPI GLFWcharmodsfun glfwSetCharModsCallback(GLFWwindow* window, GLFWcharmods
  *  @callback_signature
  *  @code
  *  void function_name(GLFWwindow* window,
-                       int preedit_length,
+                       int preedit_count,
                        unsigned int* preedit_string,
                        int block_count,
                        int* block_sizes,

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -683,17 +683,17 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     NSString* markedTextString = markedText.string;
 
     NSUInteger textLen = [markedTextString length];
-    int textAllcLen = window->preeditLengthAllocated;
-    while (textAllcLen < textLen + 1)
-        textAllcLen = textAllcLen == 0 ? 1 : textAllcLen * 2;
-    if (textAllcLen != window->preeditLengthAllocated)
+    int textBufferCount = window->preeditBufferCount;
+    while (textBufferCount < textLen + 1)
+        textBufferCount = textBufferCount == 0 ? 1 : textBufferCount * 2;
+    if (textBufferCount != window->preeditBufferCount)
     {
         unsigned int* preeditText = realloc(window->preeditText,
-                                            sizeof(unsigned int) * textAllcLen);
+                                            sizeof(unsigned int) * textBufferCount);
         if (preeditText == NULL)
             return;
         window->preeditText = preeditText;
-        window->preeditLengthAllocated = textAllcLen;
+        window->preeditBufferCount = textBufferCount;
     }
 
     // NSString handles text data in UTF16 by default, so we have to convert them
@@ -711,16 +711,16 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
         [markedText attributesAtIndex:range.location
                        effectiveRange:&currentBlockRange];
 
-        if (window->preeditBlockCountAllocated < 1 + currentBlockIndex)
+        if (window->preeditBlockBufferCount < 1 + currentBlockIndex)
         {
-            int blockAllcCnt = (window->preeditBlockCountAllocated == 0)
-                ? 1 : window->preeditBlockCountAllocated * 2;
+            int blockBufferCount = (window->preeditBlockBufferCount == 0)
+                ? 1 : window->preeditBlockBufferCount * 2;
             int* blocks = realloc(window->preeditBlockSizes,
-                                  sizeof(int) * blockAllcCnt);
+                                  sizeof(int) * blockBufferCount);
             if (blocks == NULL)
                 return;
             window->preeditBlockSizes = blocks;
-            window->preeditBlockCountAllocated = blockAllcCnt;
+            window->preeditBlockBufferCount = blockBufferCount;
         }
 
         if (currentBlockLocation != currentBlockRange.location)
@@ -749,7 +749,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     }
     window->preeditBlockSizes[currentBlockIndex] = currentBlockLength;
     window->preeditBlockCount = 1 + currentBlockIndex;
-    window->preeditLength = preeditTextLength;
+    window->preeditTextCount = preeditTextLength;
     window->preeditText[preeditTextLength] = 0;
     // The caret is always at the last of preedit in macOS.
     window->preeditCaretIndex = preeditTextLength;
@@ -761,7 +761,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 {
     [[markedText mutableString] setString:@""];
     window->preeditBlockCount = 0;
-    window->preeditLength = 0;
+    window->preeditTextCount = 0;
     window->preeditFocusedBlockIndex = 0;
     window->preeditCaretIndex = 0;
     _glfwInputPreedit(window);

--- a/src/input.c
+++ b/src/input.c
@@ -332,17 +332,17 @@ void _glfwInputChar(_GLFWwindow* window, uint32_t codepoint, int mods, GLFWbool 
 
 // Notifies shrared code of a preedit event
 //
-void _glfwInputPreedit(_GLFWwindow* window, int focusedBlock, int caret)
+void _glfwInputPreedit(_GLFWwindow* window)
 {
     if (window->callbacks.preedit)
     {
         window->callbacks.preedit((GLFWwindow*) window,
-                                  window->ntext,
+                                  window->preeditLength,
                                   window->preeditText,
-                                  window->nblocks,
-                                  window->preeditAttributeBlocks,
-                                  focusedBlock,
-                                  caret);
+                                  window->preeditBlockCount,
+                                  window->preeditBlockSizes,
+                                  window->preeditFocusedBlockIndex,
+                                  window->preeditCaretIndex);
     }
 }
 

--- a/src/input.c
+++ b/src/input.c
@@ -337,7 +337,7 @@ void _glfwInputPreedit(_GLFWwindow* window)
     if (window->callbacks.preedit)
     {
         window->callbacks.preedit((GLFWwindow*) window,
-                                  window->preeditLength,
+                                  window->preeditTextCount,
                                   window->preeditText,
                                   window->preeditBlockCount,
                                   window->preeditBlockSizes,

--- a/src/internal.h
+++ b/src/internal.h
@@ -552,11 +552,14 @@ struct _GLFWwindow
 
     // Preedit texts
     unsigned int*       preeditText;
-    int                 ntext;
-    int                 ctext;
-    int*                preeditAttributeBlocks;
-    int                 nblocks;
-    int                 cblocks;
+    int                 preeditLength;
+    int                 preeditLengthAllocated;
+    int*                preeditBlockSizes;
+    int                 preeditBlockCount;
+    int                 preeditBlockCountAllocated;
+    int                 preeditFocusedBlockIndex;
+    int                 preeditCaretIndex;
+
     int                 preeditCursorPosX, preeditCursorPosY, preeditCursorHeight;
 
     _GLFWcontext        context;
@@ -935,7 +938,7 @@ void _glfwInputKey(_GLFWwindow* window,
                    int key, int scancode, int action, int mods);
 void _glfwInputChar(_GLFWwindow* window,
                     uint32_t codepoint, int mods, GLFWbool plain);
-void _glfwInputPreedit(_GLFWwindow* window, int focusedBlock, int caret);
+void _glfwInputPreedit(_GLFWwindow* window);
 void _glfwInputIMEStatus(_GLFWwindow* window);
 void _glfwInputScroll(_GLFWwindow* window, double xoffset, double yoffset);
 void _glfwInputMouseClick(_GLFWwindow* window, int button, int action, int mods);

--- a/src/internal.h
+++ b/src/internal.h
@@ -552,11 +552,11 @@ struct _GLFWwindow
 
     // Preedit texts
     unsigned int*       preeditText;
-    int                 preeditLength;
-    int                 preeditLengthAllocated;
+    int                 preeditTextCount;
+    int                 preeditBufferCount;
     int*                preeditBlockSizes;
     int                 preeditBlockCount;
-    int                 preeditBlockCountAllocated;
+    int                 preeditBlockBufferCount;
     int                 preeditFocusedBlockIndex;
     int                 preeditCaretIndex;
 

--- a/src/window.c
+++ b/src/window.c
@@ -501,8 +501,8 @@ GLFWAPI void glfwDestroyWindow(GLFWwindow* handle)
     // Clear memory for preedit text
     if (window->preeditText)
         _glfw_free(window->preeditText);
-    if (window->preeditAttributeBlocks)
-        _glfw_free(window->preeditAttributeBlocks);
+    if (window->preeditBlockSizes)
+        _glfw_free(window->preeditBlockSizes);
     _glfw_free(window);
 }
 

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -557,7 +557,7 @@ static void _ximPreeditDoneCallback(XIC xic, XPointer clientData, XPointer callD
 //
 static void _ximPreeditDrawCallback(XIC xic, XPointer clientData, XIMPreeditDrawCallbackStruct *callData)
 {
-    int i, j, textLen, textAllcLen, rstart, rend;
+    int i, j, textLen, textBufferCount, rstart, rend;
     XIMText* text;
     const char* src;
     unsigned int codePoint;
@@ -568,7 +568,7 @@ static void _ximPreeditDrawCallback(XIC xic, XPointer clientData, XIMPreeditDraw
     if (!callData->text)
     {
         // preedit text is empty
-        window->preeditLength = 0;
+        window->preeditTextCount = 0;
         window->preeditBlockCount = 0;
         window->preeditFocusedBlockIndex = 0;
         window->preeditCaretIndex = 0;
@@ -584,27 +584,27 @@ static void _ximPreeditDrawCallback(XIC xic, XPointer clientData, XIMPreeditDraw
             // wchar is not supported
             return;
         }
-        textAllcLen = window->preeditLengthAllocated;
-        while (textAllcLen < textLen + 1)
+        textBufferCount = window->preeditBufferCount;
+        while (textBufferCount < textLen + 1)
         {
-            textAllcLen = (textAllcLen == 0) ? 1 : textAllcLen * 2;
+            textBufferCount = (textBufferCount == 0) ? 1 : textBufferCount * 2;
         }
-        if (textAllcLen != window->preeditLengthAllocated)
+        if (textBufferCount != window->preeditBufferCount)
         {
-            preeditText = _glfw_realloc(window->preeditText, sizeof(unsigned int) * textAllcLen);
+            preeditText = _glfw_realloc(window->preeditText, sizeof(unsigned int) * textBufferCount);
             if (preeditText == NULL)
             {
                 return;
             }
             window->preeditText = preeditText;
-            window->preeditLengthAllocated = textAllcLen;
+            window->preeditBufferCount = textBufferCount;
         }
-        window->preeditLength = textLen;
+        window->preeditTextCount = textLen;
         window->preeditText[textLen] = 0;
-        if (window->preeditBlockCountAllocated == 0)
+        if (window->preeditBlockBufferCount == 0)
         {
             window->preeditBlockSizes = _glfw_calloc(4, sizeof(int));
-            window->preeditBlockCountAllocated = 4;
+            window->preeditBlockBufferCount = 4;
         }
         src = text->string.multi_byte;
         rend = 0;
@@ -3358,7 +3358,7 @@ void _glfwResetPreeditTextX11(_GLFWwindow* window)
     if (_glfw.x11.imStyle == STYLE_OVERTHESPOT)
         return;
 
-    if (window->preeditLength == 0)
+    if (window->preeditTextCount == 0)
         return;
 
     preedit_attr = XVaCreateNestedList(0, XNPreeditState, &preedit_state, NULL);
@@ -3371,7 +3371,7 @@ void _glfwResetPreeditTextX11(_GLFWwindow* window)
     XSetICValues(ic, XNPreeditAttributes, preedit_attr, NULL);
     XFree(preedit_attr);
 
-    window->preeditLength = 0;
+    window->preeditTextCount = 0;
     window->preeditBlockCount = 0;
     window->preeditFocusedBlockIndex = 0;
     window->preeditCaretIndex = 0;

--- a/tests/events.c
+++ b/tests/events.c
@@ -456,43 +456,43 @@ static void char_callback(GLFWwindow* window, unsigned int codepoint)
            counter++, slot->number, glfwGetTime(), codepoint, string);
 }
 
-static void preedit_callback(GLFWwindow* window, int strLength,
-                             unsigned int* string, int blockLength,
-                             int* blocks, int focusedBlock, int caret)
+static void preedit_callback(GLFWwindow* window, int preeditCount,
+                             unsigned int* preeditString, int blockCount,
+                             int* blockSizes, int focusedBlock, int caret)
 {
     Slot* slot = glfwGetWindowUserPointer(window);
-    int i, blockIndex = -1, blockCount = 0;
+    int i, blockIndex = -1, remainingBlockSize = 0;
     int width, height;
     char encoded[5] = "";
     printf("%08x to %i at %0.3f: Preedit text ",
            counter++, slot->number, glfwGetTime());
-    if (strLength == 0 || blockLength == 0)
+    if (preeditCount == 0 || blockCount == 0)
     {
         printf("(empty)\n");
     }
     else
     {
-        for (i = 0; i < strLength; i++)
+        for (i = 0; i < preeditCount; i++)
         {
-            if (blockCount == 0)
+            if (remainingBlockSize == 0)
             {
                 if (blockIndex == focusedBlock)
                     printf("]");
                 blockIndex++;
-                blockCount = blocks[blockIndex];
+                remainingBlockSize = blockSizes[blockIndex];
                 printf("\n   block %d: ", blockIndex);
                 if (blockIndex == focusedBlock)
                     printf("[");
             }
             if (i == caret)
                 printf("|");
-            encode_utf8(encoded, string[i]);
+            encode_utf8(encoded, preeditString[i]);
             printf("%s", encoded);
-            blockCount--;
+            remainingBlockSize--;
         }
         if (blockIndex == focusedBlock)
             printf("]");
-        if (caret == strLength)
+        if (caret == preeditCount)
             printf("|");
         printf("\n");
         glfwGetWindowSize(window, &width, &height);

--- a/tests/input_text.c
+++ b/tests/input_text.c
@@ -517,12 +517,12 @@ static void ime_callback(GLFWwindow* window)
     printf("IME switched: %s\n", currentIMEStatus ? "ON" : "OFF");
 }
 
-static void preedit_callback(GLFWwindow* window, int strLength,
-                             unsigned int* string, int blockLength,
-                             int* blocks, int focusedBlock, int caret)
+static void preedit_callback(GLFWwindow* window, int preeditCount,
+                             unsigned int* preeditString, int blockCount,
+                             int* blockSizes, int focusedBlock, int caret)
 {
-    int blockIndex = -1, blockCount = 0;
-    if (strLength == 0 || blockLength == 0)
+    int blockIndex = -1, remainingBlockSize = 0;
+    if (preeditCount == 0 || blockCount == 0)
     {
         strcpy(preeditBuf, "(empty)");
         return;
@@ -530,7 +530,7 @@ static void preedit_callback(GLFWwindow* window, int strLength,
 
     strcpy(preeditBuf, "");
 
-    for (int i = 0; i < strLength; i++)
+    for (int i = 0; i < preeditCount; i++)
     {
         char encoded[5] = "";
 
@@ -539,7 +539,7 @@ static void preedit_callback(GLFWwindow* window, int strLength,
             if (strlen(preeditBuf) + strlen("|") < MAX_PREDIT_LEN)
                 strcat(preeditBuf, "|");
         }
-        if (blockCount == 0)
+        if (remainingBlockSize == 0)
         {
             if (blockIndex == focusedBlock)
             {
@@ -547,24 +547,24 @@ static void preedit_callback(GLFWwindow* window, int strLength,
                     strcat(preeditBuf, "]");
             }
             blockIndex++;
-            blockCount = blocks[blockIndex];
+            remainingBlockSize = blockSizes[blockIndex];
             if (blockIndex == focusedBlock)
             {
                 if (strlen(preeditBuf) + strlen("[") < MAX_PREDIT_LEN)
                     strcat(preeditBuf, "[");
             }
         }
-        encode_utf8(encoded, string[i]);
+        encode_utf8(encoded, preeditString[i]);
         if (strlen(preeditBuf) + strlen(encoded) < MAX_PREDIT_LEN)
             strcat(preeditBuf, encoded);
-        blockCount--;
+        remainingBlockSize--;
     }
     if (blockIndex == focusedBlock)
     {
         if (strlen(preeditBuf) + strlen("]") < MAX_PREDIT_LEN)
             strcat(preeditBuf, "]");
     }
-    if (caret == strLength)
+    if (caret == preeditCount)
     {
         if (strlen(preeditBuf) + strlen("|") < MAX_PREDIT_LEN)
             strcat(preeditBuf, "|");


### PR DESCRIPTION
Refactor variable names about preedit.

The signature of `_glfwInputPreedit()` is also changed.
