### PR TITLE
macOS: Fix _glfwSetIMEStatusCocoa failed with some locales

### DIFF
--- a/src/cocoa_init.m
+++ b/src/cocoa_init.m
@@ -363,9 +363,15 @@ static GLFWbool initializeTIS(void)
     CFStringRef* kPropertyInputSourceIsSelectCapable =
         CFBundleGetDataPointerForName(_glfw.ns.tis.bundle,
                                       CFSTR("kTISPropertyInputSourceIsSelectCapable"));
+    CFStringRef* kPropertyInputSourceType =
+        CFBundleGetDataPointerForName(_glfw.ns.tis.bundle,
+                                      CFSTR("kTISPropertyInputSourceType"));
     CFStringRef* kPropertyUnicodeKeyLayoutData =
         CFBundleGetDataPointerForName(_glfw.ns.tis.bundle,
                                       CFSTR("kTISPropertyUnicodeKeyLayoutData"));
+    CFStringRef* kTypeKeyboardInputMethodModeEnabled =
+        CFBundleGetDataPointerForName(_glfw.ns.tis.bundle,
+                                      CFSTR("kTISTypeKeyboardInputMethodModeEnabled"));
     _glfw.ns.tis.CopyCurrentASCIICapableKeyboardInputSource =
         CFBundleGetFunctionPointerForName(_glfw.ns.tis.bundle,
                                           CFSTR("TISCopyCurrentASCIICapableKeyboardInputSource"));
@@ -398,7 +404,9 @@ static GLFWbool initializeTIS(void)
         !kPropertyInputSourceCategory ||
         !kPropertyInputSourceID ||
         !kPropertyInputSourceIsSelectCapable||
+        !kPropertyInputSourceType||
         !kPropertyUnicodeKeyLayoutData ||
+        !kTypeKeyboardInputMethodModeEnabled ||
         !TISCopyCurrentASCIICapableKeyboardInputSource ||
         !TISCopyCurrentKeyboardInputSource ||
         !TISCopyCurrentKeyboardLayoutInputSource ||
@@ -422,8 +430,12 @@ static GLFWbool initializeTIS(void)
         *kPropertyInputSourceID;
     _glfw.ns.tis.kPropertyInputSourceIsSelectCapable =
         *kPropertyInputSourceIsSelectCapable;
+    _glfw.ns.tis.kPropertyInputSourceType =
+        *kPropertyInputSourceType;
     _glfw.ns.tis.kPropertyUnicodeKeyLayoutData =
         *kPropertyUnicodeKeyLayoutData;
+    _glfw.ns.tis.kTypeKeyboardInputMethodModeEnabled =
+        *kTypeKeyboardInputMethodModeEnabled;
 
     return updateUnicodeData();
 }

--- a/src/cocoa_init.m
+++ b/src/cocoa_init.m
@@ -357,6 +357,15 @@ static GLFWbool initializeTIS(void)
     CFStringRef* kPropertyUnicodeKeyLayoutData =
         CFBundleGetDataPointerForName(_glfw.ns.tis.bundle,
                                       CFSTR("kTISPropertyUnicodeKeyLayoutData"));
+    CFStringRef* kPropertyInputSourceCategory =
+        CFBundleGetDataPointerForName(_glfw.ns.tis.bundle,
+                                      CFSTR("kTISPropertyInputSourceCategory"));
+    CFStringRef* kCategoryKeyboardInputSource =
+        CFBundleGetDataPointerForName(_glfw.ns.tis.bundle,
+                                      CFSTR("kTISCategoryKeyboardInputSource"));
+    CFStringRef* kPropertyInputSourceIsSelectCapable =
+        CFBundleGetDataPointerForName(_glfw.ns.tis.bundle,
+                                      CFSTR("kTISPropertyInputSourceIsSelectCapable"));
     _glfw.ns.tis.CopyCurrentASCIICapableKeyboardInputSource =
         CFBundleGetFunctionPointerForName(_glfw.ns.tis.bundle,
                                           CFSTR("TISCopyCurrentASCIICapableKeyboardInputSource"));
@@ -381,9 +390,16 @@ static GLFWbool initializeTIS(void)
     _glfw.ns.tis.GetKbdType =
         CFBundleGetFunctionPointerForName(_glfw.ns.tis.bundle,
                                           CFSTR("LMGetKbdType"));
+    _glfw.ns.tis.CreateInputSourceList =
+          CFBundleGetFunctionPointerForName(_glfw.ns.tis.bundle,
+                                          CFSTR("TISCreateInputSourceList"));
 
     if (!kPropertyInputSourceID ||
         !kPropertyUnicodeKeyLayoutData ||
+        !kPropertyInputSourceCategory ||
+        !kCategoryKeyboardInputSource||
+        !kPropertyInputSourceIsSelectCapable||
+        !TISCreateInputSourceList ||
         !TISCopyCurrentASCIICapableKeyboardInputSource ||
         !TISCopyCurrentKeyboardInputSource ||
         !TISCopyCurrentKeyboardLayoutInputSource ||
@@ -402,6 +418,12 @@ static GLFWbool initializeTIS(void)
         *kPropertyInputSourceID;
     _glfw.ns.tis.kPropertyUnicodeKeyLayoutData =
         *kPropertyUnicodeKeyLayoutData;
+    _glfw.ns.tis.kPropertyInputSourceCategory =
+            *kPropertyInputSourceCategory;
+    _glfw.ns.tis.kCategoryKeyboardInputSource =
+            *kCategoryKeyboardInputSource;
+    _glfw.ns.tis.kPropertyInputSourceIsSelectCapable =
+            *kPropertyInputSourceIsSelectCapable;
 
     return updateUnicodeData();
 }

--- a/src/cocoa_init.m
+++ b/src/cocoa_init.m
@@ -351,21 +351,21 @@ static GLFWbool initializeTIS(void)
         return GLFW_FALSE;
     }
 
-    CFStringRef* kPropertyInputSourceID =
-        CFBundleGetDataPointerForName(_glfw.ns.tis.bundle,
-                                      CFSTR("kTISPropertyInputSourceID"));
-    CFStringRef* kPropertyUnicodeKeyLayoutData =
-        CFBundleGetDataPointerForName(_glfw.ns.tis.bundle,
-                                      CFSTR("kTISPropertyUnicodeKeyLayoutData"));
-    CFStringRef* kPropertyInputSourceCategory =
-        CFBundleGetDataPointerForName(_glfw.ns.tis.bundle,
-                                      CFSTR("kTISPropertyInputSourceCategory"));
     CFStringRef* kCategoryKeyboardInputSource =
         CFBundleGetDataPointerForName(_glfw.ns.tis.bundle,
                                       CFSTR("kTISCategoryKeyboardInputSource"));
+    CFStringRef* kPropertyInputSourceCategory =
+        CFBundleGetDataPointerForName(_glfw.ns.tis.bundle,
+                                      CFSTR("kTISPropertyInputSourceCategory"));
+    CFStringRef* kPropertyInputSourceID =
+        CFBundleGetDataPointerForName(_glfw.ns.tis.bundle,
+                                      CFSTR("kTISPropertyInputSourceID"));
     CFStringRef* kPropertyInputSourceIsSelectCapable =
         CFBundleGetDataPointerForName(_glfw.ns.tis.bundle,
                                       CFSTR("kTISPropertyInputSourceIsSelectCapable"));
+    CFStringRef* kPropertyUnicodeKeyLayoutData =
+        CFBundleGetDataPointerForName(_glfw.ns.tis.bundle,
+                                      CFSTR("kTISPropertyUnicodeKeyLayoutData"));
     _glfw.ns.tis.CopyCurrentASCIICapableKeyboardInputSource =
         CFBundleGetFunctionPointerForName(_glfw.ns.tis.bundle,
                                           CFSTR("TISCopyCurrentASCIICapableKeyboardInputSource"));
@@ -381,6 +381,9 @@ static GLFWbool initializeTIS(void)
     _glfw.ns.tis.CreateASCIICapableInputSourceList =
         CFBundleGetFunctionPointerForName(_glfw.ns.tis.bundle,
                                           CFSTR("TISCreateASCIICapableInputSourceList"));
+    _glfw.ns.tis.CreateInputSourceList =
+        CFBundleGetFunctionPointerForName(_glfw.ns.tis.bundle,
+                                          CFSTR("TISCreateInputSourceList"));
     _glfw.ns.tis.GetInputSourceProperty =
         CFBundleGetFunctionPointerForName(_glfw.ns.tis.bundle,
                                           CFSTR("TISGetInputSourceProperty"));
@@ -390,21 +393,18 @@ static GLFWbool initializeTIS(void)
     _glfw.ns.tis.GetKbdType =
         CFBundleGetFunctionPointerForName(_glfw.ns.tis.bundle,
                                           CFSTR("LMGetKbdType"));
-    _glfw.ns.tis.CreateInputSourceList =
-          CFBundleGetFunctionPointerForName(_glfw.ns.tis.bundle,
-                                          CFSTR("TISCreateInputSourceList"));
 
-    if (!kPropertyInputSourceID ||
-        !kPropertyUnicodeKeyLayoutData ||
+    if (!kCategoryKeyboardInputSource||
         !kPropertyInputSourceCategory ||
-        !kCategoryKeyboardInputSource||
+        !kPropertyInputSourceID ||
         !kPropertyInputSourceIsSelectCapable||
-        !TISCreateInputSourceList ||
+        !kPropertyUnicodeKeyLayoutData ||
         !TISCopyCurrentASCIICapableKeyboardInputSource ||
         !TISCopyCurrentKeyboardInputSource ||
         !TISCopyCurrentKeyboardLayoutInputSource ||
         !TISCopyInputSourceForLanguage ||
         !TISCreateASCIICapableInputSourceList ||
+        !TISCreateInputSourceList ||
         !TISGetInputSourceProperty ||
         !TISSelectInputSource ||
         !LMGetKbdType)
@@ -414,16 +414,16 @@ static GLFWbool initializeTIS(void)
         return GLFW_FALSE;
     }
 
+    _glfw.ns.tis.kCategoryKeyboardInputSource =
+        *kCategoryKeyboardInputSource;
+    _glfw.ns.tis.kPropertyInputSourceCategory =
+        *kPropertyInputSourceCategory;
     _glfw.ns.tis.kPropertyInputSourceID =
         *kPropertyInputSourceID;
+    _glfw.ns.tis.kPropertyInputSourceIsSelectCapable =
+        *kPropertyInputSourceIsSelectCapable;
     _glfw.ns.tis.kPropertyUnicodeKeyLayoutData =
         *kPropertyUnicodeKeyLayoutData;
-    _glfw.ns.tis.kPropertyInputSourceCategory =
-            *kPropertyInputSourceCategory;
-    _glfw.ns.tis.kCategoryKeyboardInputSource =
-            *kCategoryKeyboardInputSource;
-    _glfw.ns.tis.kPropertyInputSourceIsSelectCapable =
-            *kPropertyInputSourceIsSelectCapable;
 
     return updateUnicodeData();
 }

--- a/src/cocoa_platform.h
+++ b/src/cocoa_platform.h
@@ -111,6 +111,11 @@ typedef VkResult (APIENTRY *PFN_vkCreateMetalSurfaceEXT)(VkInstance,const VkMeta
 // HIToolbox.framework pointer typedefs
 #define kTISPropertyInputSourceID _glfw.ns.tis.kPropertyInputSourceID
 #define kTISPropertyUnicodeKeyLayoutData _glfw.ns.tis.kPropertyUnicodeKeyLayoutData
+#define kTISPropertyInputSourceCategory _glfw.ns.tis.kPropertyInputSourceCategory
+#define kTISCategoryKeyboardInputSource _glfw.ns.tis.kCategoryKeyboardInputSource
+#define kTISPropertyInputSourceIsSelectCapable _glfw.ns.tis.kPropertyInputSourceIsSelectCapable
+typedef CFArrayRef (*PEN_TISCreateInputSourceList)(CFDictionaryRef,Boolean);
+#define TISCreateInputSourceList _glfw.ns.tis.CreateInputSourceList
 typedef TISInputSourceRef (*PFN_TISCopyCurrentASCIICapableKeyboardInputSource)(void);
 #define TISCopyCurrentASCIICapableKeyboardInputSource _glfw.ns.tis.CopyCurrentASCIICapableKeyboardInputSource
 typedef TISInputSourceRef (*PFN_TISCopyCurrentKeyboardInputSource)(void);
@@ -203,6 +208,10 @@ typedef struct _GLFWlibraryNS
         PFN_TISGetInputSourceProperty GetInputSourceProperty;
         PFN_TISSelectInputSource SelectInputSource;
         PFN_LMGetKbdType GetKbdType;
+        PEN_TISCreateInputSourceList CreateInputSourceList;
+        CFStringRef     kPropertyInputSourceCategory;
+        CFStringRef     kCategoryKeyboardInputSource;
+        CFStringRef     kPropertyInputSourceIsSelectCapable;
         CFStringRef     kPropertyInputSourceID;
         CFStringRef     kPropertyUnicodeKeyLayoutData;
     } tis;

--- a/src/cocoa_platform.h
+++ b/src/cocoa_platform.h
@@ -109,13 +109,11 @@ typedef VkResult (APIENTRY *PFN_vkCreateMetalSurfaceEXT)(VkInstance,const VkMeta
 #define GLFW_NSGL_LIBRARY_CONTEXT_STATE _GLFWlibraryNSGL nsgl;
 
 // HIToolbox.framework pointer typedefs
-#define kTISPropertyInputSourceID _glfw.ns.tis.kPropertyInputSourceID
-#define kTISPropertyUnicodeKeyLayoutData _glfw.ns.tis.kPropertyUnicodeKeyLayoutData
-#define kTISPropertyInputSourceCategory _glfw.ns.tis.kPropertyInputSourceCategory
 #define kTISCategoryKeyboardInputSource _glfw.ns.tis.kCategoryKeyboardInputSource
+#define kTISPropertyInputSourceCategory _glfw.ns.tis.kPropertyInputSourceCategory
+#define kTISPropertyInputSourceID _glfw.ns.tis.kPropertyInputSourceID
 #define kTISPropertyInputSourceIsSelectCapable _glfw.ns.tis.kPropertyInputSourceIsSelectCapable
-typedef CFArrayRef (*PEN_TISCreateInputSourceList)(CFDictionaryRef,Boolean);
-#define TISCreateInputSourceList _glfw.ns.tis.CreateInputSourceList
+#define kTISPropertyUnicodeKeyLayoutData _glfw.ns.tis.kPropertyUnicodeKeyLayoutData
 typedef TISInputSourceRef (*PFN_TISCopyCurrentASCIICapableKeyboardInputSource)(void);
 #define TISCopyCurrentASCIICapableKeyboardInputSource _glfw.ns.tis.CopyCurrentASCIICapableKeyboardInputSource
 typedef TISInputSourceRef (*PFN_TISCopyCurrentKeyboardInputSource)(void);
@@ -126,6 +124,8 @@ typedef TISInputSourceRef (*PFN_TISCopyInputSourceForLanguage)(CFStringRef);
 #define TISCopyInputSourceForLanguage _glfw.ns.tis.CopyInputSourceForLanguage
 typedef CFArrayRef (*PFN_TISCreateASCIICapableInputSourceList)(void);
 #define TISCreateASCIICapableInputSourceList _glfw.ns.tis.CreateASCIICapableInputSourceList
+typedef CFArrayRef (*PEN_TISCreateInputSourceList)(CFDictionaryRef,Boolean);
+#define TISCreateInputSourceList _glfw.ns.tis.CreateInputSourceList
 typedef void* (*PFN_TISGetInputSourceProperty)(TISInputSourceRef,CFStringRef);
 #define TISGetInputSourceProperty _glfw.ns.tis.GetInputSourceProperty
 typedef OSStatus (*PFN_TISSelectInputSource)(TISInputSourceRef);
@@ -205,14 +205,14 @@ typedef struct _GLFWlibraryNS
         PFN_TISCopyCurrentKeyboardLayoutInputSource CopyCurrentKeyboardLayoutInputSource;
         PFN_TISCopyInputSourceForLanguage CopyInputSourceForLanguage;
         PFN_TISCreateASCIICapableInputSourceList CreateASCIICapableInputSourceList;
+        PEN_TISCreateInputSourceList CreateInputSourceList;
         PFN_TISGetInputSourceProperty GetInputSourceProperty;
         PFN_TISSelectInputSource SelectInputSource;
         PFN_LMGetKbdType GetKbdType;
-        PEN_TISCreateInputSourceList CreateInputSourceList;
-        CFStringRef     kPropertyInputSourceCategory;
         CFStringRef     kCategoryKeyboardInputSource;
-        CFStringRef     kPropertyInputSourceIsSelectCapable;
+        CFStringRef     kPropertyInputSourceCategory;
         CFStringRef     kPropertyInputSourceID;
+        CFStringRef     kPropertyInputSourceIsSelectCapable;
         CFStringRef     kPropertyUnicodeKeyLayoutData;
     } tis;
 } _GLFWlibraryNS;

--- a/src/cocoa_platform.h
+++ b/src/cocoa_platform.h
@@ -113,7 +113,9 @@ typedef VkResult (APIENTRY *PFN_vkCreateMetalSurfaceEXT)(VkInstance,const VkMeta
 #define kTISPropertyInputSourceCategory _glfw.ns.tis.kPropertyInputSourceCategory
 #define kTISPropertyInputSourceID _glfw.ns.tis.kPropertyInputSourceID
 #define kTISPropertyInputSourceIsSelectCapable _glfw.ns.tis.kPropertyInputSourceIsSelectCapable
+#define kTISPropertyInputSourceType _glfw.ns.tis.kPropertyInputSourceType
 #define kTISPropertyUnicodeKeyLayoutData _glfw.ns.tis.kPropertyUnicodeKeyLayoutData
+#define kTISTypeKeyboardInputMethodModeEnabled _glfw.ns.tis.kTypeKeyboardInputMethodModeEnabled
 typedef TISInputSourceRef (*PFN_TISCopyCurrentASCIICapableKeyboardInputSource)(void);
 #define TISCopyCurrentASCIICapableKeyboardInputSource _glfw.ns.tis.CopyCurrentASCIICapableKeyboardInputSource
 typedef TISInputSourceRef (*PFN_TISCopyCurrentKeyboardInputSource)(void);
@@ -213,7 +215,9 @@ typedef struct _GLFWlibraryNS
         CFStringRef     kPropertyInputSourceCategory;
         CFStringRef     kPropertyInputSourceID;
         CFStringRef     kPropertyInputSourceIsSelectCapable;
+        CFStringRef     kPropertyInputSourceType;
         CFStringRef     kPropertyUnicodeKeyLayoutData;
+        CFStringRef     kTypeKeyboardInputMethodModeEnabled;
     } tis;
 } _GLFWlibraryNS;
 

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -2031,8 +2031,32 @@ void _glfwSetIMEStatusCocoa(_GLFWwindow* window, int active)
         if (locale)
         {
             TISInputSourceRef source = TISCopyInputSourceForLanguage(locale);
-            TISSelectInputSource(source);
-            CFRelease(source);
+            if (source)
+            {
+                NSString* sourceID =
+                    (__bridge NSString *) TISGetInputSourceProperty(source, kTISPropertyInputSourceID);
+
+                NSDictionary* properties = @{
+                    (__bridge NSString*)kTISPropertyInputSourceCategory: (__bridge NSString*)kTISCategoryKeyboardInputSource,
+                    (__bridge NSString*)kTISPropertyInputSourceIsSelectCapable: @YES,
+                    };
+                NSArray* sources =
+                        CFBridgingRelease(TISCreateInputSourceList((__bridge CFDictionaryRef)properties, NO));
+
+                for (id sourceObj in sources)
+                {
+                    TISInputSourceRef ref = (__bridge TISInputSourceRef)sourceObj;
+                    NSString* refID =
+                        (__bridge NSString *) TISGetInputSourceProperty(ref, kTISPropertyInputSourceID);
+
+                    if ([refID containsString:sourceID]){
+                        TISSelectInputSource(ref);
+                        break;
+                    }
+                }
+
+                CFRelease(source);
+            }
         }
     }
     else

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -2025,8 +2025,7 @@ void _glfwSetIMEStatusCocoa(_GLFWwindow* window, int active)
     if (active)
     {
         NSArray* locales = CFBridgingRelease(CFLocaleCopyPreferredLanguages());
-        // Not assuming an environment with multiple preferred locales, but if
-        // there are, select the first one anyway.
+        // Select the most preferred locale.
         CFStringRef locale = (__bridge CFStringRef) [locales firstObject];
         if (locale)
         {
@@ -2037,20 +2036,21 @@ void _glfwSetIMEStatusCocoa(_GLFWwindow* window, int active)
                     (__bridge NSString *) TISGetInputSourceProperty(source, kTISPropertyInputSourceID);
 
                 NSDictionary* properties = @{
-                    (__bridge NSString*)kTISPropertyInputSourceCategory: (__bridge NSString*)kTISCategoryKeyboardInputSource,
-                    (__bridge NSString*)kTISPropertyInputSourceIsSelectCapable: @YES,
+                    (__bridge NSString *) kTISPropertyInputSourceCategory: (__bridge NSString *) kTISCategoryKeyboardInputSource,
+                    (__bridge NSString *) kTISPropertyInputSourceIsSelectCapable: @YES,
                     };
-                NSArray* sources =
-                        CFBridgingRelease(TISCreateInputSourceList((__bridge CFDictionaryRef)properties, NO));
+                NSArray* selectableSources =
+                    CFBridgingRelease(TISCreateInputSourceList((__bridge CFDictionaryRef) properties, NO));
 
-                for (id sourceObj in sources)
+                for (id sourceCandidate in selectableSources)
                 {
-                    TISInputSourceRef ref = (__bridge TISInputSourceRef)sourceObj;
-                    NSString* refID =
-                        (__bridge NSString *) TISGetInputSourceProperty(ref, kTISPropertyInputSourceID);
+                    TISInputSourceRef sourceCandidateRef = (__bridge TISInputSourceRef) sourceCandidate;
+                    NSString* sourceCandidateID =
+                        (__bridge NSString *) TISGetInputSourceProperty(sourceCandidateRef, kTISPropertyInputSourceID);
 
-                    if ([refID containsString:sourceID]){
-                        TISSelectInputSource(ref);
+                    if ([sourceCandidateID hasPrefix:sourceID])
+                    {
+                        TISSelectInputSource(sourceCandidateRef);
                         break;
                     }
                 }


### PR DESCRIPTION
Thank you very much for this PR. I use GLFW on macOS 12.3, and the user language is simplified Chinese.
I found that `glfwSetInputMode(window, GLFW_IME, GLFW_TRUE)` not working. (Set to False is working)

After digging into the code, I found that the problem lies in the following three line:
https://github.com/clear-code/glfw/blob/51564dc0e04bd371100360d18cc3a5567f1be22e/src/cocoa_window.m#L2019-L2021

1. If I remove all the input methods in system setting, the `source` is null, `CFRelease(source)` or `TISSelectInputSource(source)`  Will cause program crash.
2. the ID (kTISPropertyInputSourceID) of `source` is `com.apple.inputmethod.SCIM` (Stands for simplified Chinese ) but It's not a real input method, so `TISSelectInputSource` set a nonexistent input method. The ID of real input method is `com.apple.inputmethod.SCIM.ITABC`. 

My fix is to get all the currently enabled input methods, and compared whether the prefix strings are equal to `source` , then set the first matching input method to on.

Another problem is that I don't know why this fix will cause the IMEStatusCallback to be triggered multiple times after each change. It ok to not accept this PR, , I just don't know where to discuss this issue.

Thank you again for your great PR.

