### PR TITLE
WIN32: Better support for IME

### DIFF
--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -186,6 +186,8 @@ static GLFWbool loadLibraries(void)
             _glfwPlatformGetModuleSymbol(_glfw.win32.imm32.instance, "ImmNotifyIME");
         _glfw.win32.imm32.ImmReleaseContext_ = (PFN_ImmReleaseContext)
             _glfwPlatformGetModuleSymbol(_glfw.win32.imm32.instance, "ImmReleaseContext");
+        _glfw.win32.imm32.ImmSetCompositionWindow_ = (PFN_ImmSetCompositionWindow)
+            _glfwPlatformGetModuleSymbol(_glfw.win32.imm32.instance, "ImmSetCompositionWindow");
         _glfw.win32.imm32.ImmSetCandidateWindow_ = (PFN_ImmSetCandidateWindow)
             _glfwPlatformGetModuleSymbol(_glfw.win32.imm32.instance, "ImmSetCandidateWindow");
         _glfw.win32.imm32.ImmSetOpenStatus_ = (PFN_ImmSetOpenStatus)

--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -326,6 +326,7 @@ typedef UINT (WINAPI * PFN_ImmGetDescriptionW)(HKL,LPWSTR,UINT);
 typedef BOOL (WINAPI * PFN_ImmGetOpenStatus)(HIMC);
 typedef BOOL (WINAPI * PFN_ImmNotifyIME)(HIMC,DWORD,DWORD,DWORD);
 typedef BOOL (WINAPI * PFN_ImmReleaseContext)(HWND,HIMC);
+typedef BOOL (WINAPI * PFN_ImmSetCompositionWindow)(HIMC,LPCOMPOSITIONFORM);
 typedef BOOL (WINAPI * PFN_ImmSetCandidateWindow)(HIMC,LPCANDIDATEFORM);
 typedef BOOL (WINAPI * PFN_ImmSetOpenStatus)(HIMC,BOOL);
 #define ImmGetCandidateListW _glfw.win32.imm32.ImmGetCandidateListW_
@@ -336,6 +337,7 @@ typedef BOOL (WINAPI * PFN_ImmSetOpenStatus)(HIMC,BOOL);
 #define ImmGetOpenStatus _glfw.win32.imm32.ImmGetOpenStatus_
 #define ImmNotifyIME _glfw.win32.imm32.ImmNotifyIME_
 #define ImmReleaseContext _glfw.win32.imm32.ImmReleaseContext_
+#define ImmSetCompositionWindow _glfw.win32.imm32.ImmSetCompositionWindow_
 #define ImmSetCandidateWindow _glfw.win32.imm32.ImmSetCandidateWindow_
 #define ImmSetOpenStatus _glfw.win32.imm32.ImmSetOpenStatus_
 
@@ -536,6 +538,7 @@ typedef struct _GLFWlibraryWin32
         PFN_ImmGetOpenStatus            ImmGetOpenStatus_;
         PFN_ImmNotifyIME                ImmNotifyIME_;
         PFN_ImmReleaseContext           ImmReleaseContext_;
+        PFN_ImmSetCompositionWindow     ImmSetCompositionWindow_;
         PFN_ImmSetCandidateWindow       ImmSetCandidateWindow_;
         PFN_ImmSetOpenStatus            ImmSetOpenStatus_;
     } imm32;

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -2867,8 +2867,11 @@ void _glfwUpdatePreeditCursorRectangleWin32(_GLFWwindow* window)
     int y = preedit->cursorPosY;
     int w = preedit->cursorWidth;
     int h = preedit->cursorHeight;
-    CANDIDATEFORM excludeRect = { 0, CFS_EXCLUDE, { x, y }, { x, y, x + w, y + h } };
 
+    COMPOSITIONFORM areaRect = { CFS_RECT, { x, y }, { x, y, x + w, y + h } };
+    ImmSetCompositionWindow(hIMC, &areaRect);
+
+    CANDIDATEFORM excludeRect = { 0, CFS_EXCLUDE, { x, y }, { x, y, x + w, y + h } };
     ImmSetCandidateWindow(hIMC, &excludeRect);
 
     ImmReleaseContext(hWnd, hIMC);


### PR DESCRIPTION
In Windows, glfwSetPreeditCursorRectangle occasionally fails:
1.  Win11 default Chinese PinYin input method, sometimes displayed in the correct position, sometimes appearing in the bottom right corner of the screen
2. Some third-party input methods always display at incorrect positions (such as [Sogou input method](https://pinyin.sogou.com/windows/?r=mac&t=pinyin)) 

By comparing the implementation of SDL2, it is found that calling ImmSetCompositionWindow before ImmSetCandidateWindow can solve this problem.

https://github.com/libsdl-org/SDL/blob/f7877902436eae72e3931b2d9ab9d213e095baab/src/video/windows/SDL_windowskeyboard.c#L642-L686